### PR TITLE
Minor bugfix if BrewServicesMenubar causes brew to tap the homebrew/services repository

### DIFF
--- a/BrewServicesMenubar.xcodeproj/project.pbxproj
+++ b/BrewServicesMenubar.xcodeproj/project.pbxproj
@@ -96,7 +96,7 @@
 			};
 			buildConfigurationList = 49ED77A91CD4B524000B4479 /* Build configuration list for PBXProject "BrewServicesMenubar" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -243,7 +243,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = andrewnicolaou.BrewServicesMenubar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -256,7 +256,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = andrewnicolaou.BrewServicesMenubar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/BrewServicesMenubar/AppDelegate.swift
+++ b/BrewServicesMenubar/AppDelegate.swift
@@ -230,7 +230,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func parseServiceList(_ raw: String) -> [Service] {
         let rawServices = raw.components(separatedBy: "\n")
-        return rawServices[1..<rawServices.count].map(parseService)
+        var services:ArraySlice<String>
+        if rawServices[0].starts(with: "==>") {
+            // Skip two extra lines if this is the first invocation of "brew services list", which will cause Homebrew to tap the homebrew/services repository
+            services = rawServices[3..<rawServices.count]
+        }
+        else {
+            // Skip the header before the services are listed
+            services = rawServices[1..<rawServices.count]
+        }
+        return services.map(parseService)
     }
 
     func parseService(_ raw:String) -> Service {

--- a/BrewServicesMenubar/AppDelegate.swift
+++ b/BrewServicesMenubar/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var statusMenu: NSMenu!
 
     // Returns a status item from the system menu bar of variable length
-    let statusItem = NSStatusBar.system().statusItem(withLength: -1)
+    let statusItem = NSStatusBar.system.statusItem(withLength: -1)
     var services: [Service]?
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
@@ -44,38 +44,38 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     //
     // Event handlers for UI actions
     //
-    func handleClick(_ sender: NSMenuItem) {
-        if sender.state == NSOnState {
-            sender.state = NSOffState
+    @objc func handleClick(_ sender: NSMenuItem) {
+        if sender.state == NSControl.StateValue.on {
+            sender.state = NSControl.StateValue.off
             controlService(sender.title, state: "stop")
         } else {
-            sender.state = NSOnState
+            sender.state = NSControl.StateValue.on
             controlService(sender.title, state: "start")
         }
     }
 
-    func handleRestartClick(_ sender: NSMenuItem) {
+    @objc func handleRestartClick(_ sender: NSMenuItem) {
         let service = sender.representedObject as! Service
         controlService(service.name, state: "restart")
     }
 
-    func handleStartAll(_ sender: NSMenuItem) {
+    @objc func handleStartAll(_ sender: NSMenuItem) {
         controlService("--all", state: "start")
     }
 
-    func handleStopAll(_ sender: NSMenuItem) {
+    @objc func handleStopAll(_ sender: NSMenuItem) {
         controlService("--all", state: "stop")
     }
 
-    func handleRestartAll(_ sender: NSMenuItem) {
+    @objc func handleRestartAll(_ sender: NSMenuItem) {
         controlService("--all", state: "restart")
     }
 
-    func handleQuit(_ sender: NSMenuItem) {
+    @objc func handleQuit(_ sender: NSMenuItem) {
         NSApp.terminate(nil)
     }
 
-    func handleMenuOpen(_ sender: AnyObject?) {
+    @objc func handleMenuOpen(_ sender: AnyObject?) {
         queryServicesAndUpdateMenu()
         statusItem.popUpMenu(statusMenu)
     }
@@ -92,11 +92,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 let item = NSMenuItem.init(title: service.name, action: nil, keyEquivalent: "")
 
                 if service.state == "started" {
-                    item.state = NSOnState
+                    item.state = NSControl.StateValue.on
                 } else if service.state == "stopped" {
-                    item.state = NSOffState
+                    item.state = NSControl.StateValue.off
                 } else {
-                    item.state = NSMixedState
+                    item.state = NSControl.StateValue.mixed
                     item.isEnabled = false
                 }
 
@@ -116,7 +116,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 altItem.isEnabled = item.isEnabled
                 altItem.isAlternate = true
                 altItem.isHidden = true
-                altItem.keyEquivalentModifierMask = NSAlternateKeyMask
+                altItem.keyEquivalentModifierMask = .option
                 statusMenu.addItem(altItem)
             }
             if services.count == 0 {

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ This reads the [homebrew-services](https://github.com/Homebrew/homebrew-services
 
 ## Usage
 
-- Start a specific service by clicking it's name
+- Start a specific service by clicking its name
 - Stop a specific running service (indicated with a tick) by clicking its name
-- Hold the Option key to allow a single service to be restarted
+- Hold the <kbd>Option</kbd> key to allow a single service to be restarted
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ This reads the [homebrew-services](https://github.com/Homebrew/homebrew-services
 ## Usage
 
 - Start a specific service by clicking it's name
-- Stop a specific running service (indicated with a tick) by clicking it's name
-- Hold Command to allow a single service to be restarted
+- Stop a specific running service (indicated with a tick) by clicking its name
+- Hold the Option key to allow a single service to be restarted
 
 ## Configuration
 


### PR DESCRIPTION
I set up a new Macbook recently, and I noticed an interesting oddity the first time I ran BrewServicesMenubar.

![Screen Shot 2020-09-03 at 14 56 14](https://user-images.githubusercontent.com/1991151/92352260-8a09a200-f092-11ea-8bfb-f00aba17a84c.png)

It turns out that I had not run `brew services` in the terminal before, so what I saw was caused by extra output in the output from `brew services list`. Simply closing and reopening the menu fixed the problem, and as expected the issue did not re-appear.

Normally it prints this on stdout:
```
Name    Status  User Plist
caddy   stopped
unbound stopped
```

But if you haven't run a `brew services` command before, it will print:
```
==> Tapping homebrew/services
Tapped 1 command (40 files, 338.6KB).
Name    Status  User Plist
caddy   stopped
unbound stopped
```

Test this easily by deleting `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-services` and then running:
```
brew services list 2>/dev/null
```

(git prints a line to stderr)

So it is an easy fix. I actually started looking in the Homebrew source code to see if I could ask them if they wanted to send the `==> Tapping` output to stderr, but I wasn't able to find the place to change it in the source code. So I thought I will explain the issue here and then open an issue in the Homebrew repository and link this so that they can better understand the problem. So for this reason we may not need to merge this PR at all. Let's wait and see.

I was not able to open the project with XCode because apparently Swift 3 is deprecated. I hoped #10 would fix it, but there I had to also change a `3.0` to `5.0`. I ended up using some code from #10 to fix the compatibility.

I also fixed a minor bug in the README.