### PR TITLE
Updated brew install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This reads the [homebrew-services](https://github.com/Homebrew/homebrew-services
 
 ### using Homebrew-Cask
 
-2. `brew cask install brewservicesmenubar`
+2. `brew install --cask brewservicesmenubar`
 
 ### manually
 


### PR DESCRIPTION
brew cask <command> was deprecated in favor of brew <command> --cask in Homebrew 2.6.0.

I updated the command in the README to reflect these changes.