### PR TITLE
add none status to potential statuses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Thumbs.db
 xcshareddata
 xcuserdata
 DerivedData
+.idea/

--- a/BrewServicesMenubar/AppDelegate.swift
+++ b/BrewServicesMenubar/AppDelegate.swift
@@ -12,7 +12,7 @@ let brewExecutableKey = "brewExecutable"
 
 struct Service {
     var name = ""
-    var state = "unknown" // "started", "stopped", "error", "unknown"
+    var state = "unknown" // "started", "stopped", "none", "error", "unknown"
     var user = ""
 }
 
@@ -114,7 +114,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
                 if service.state == "started" {
                     item.state = NSControl.StateValue.on
-                } else if service.state == "stopped" {
+                } else if service.state == "stopped"  || service.state == "none" {
                     item.state = NSControl.StateValue.off
                 } else {
                     item.state = NSControl.StateValue.mixed


### PR DESCRIPTION
Currently, the menubar shows "-" for statuses that are "none". This looks to be a new status type that appears when typing `brew services list`.